### PR TITLE
Fix log method for keyword args

### DIFF
--- a/lib/ar_multi_threaded_transactional_tests.rb
+++ b/lib/ar_multi_threaded_transactional_tests.rb
@@ -51,7 +51,7 @@ module ArMultiThreadedTransactionalTests
   end
 
   module ExecutionSyncer
-    def log(*)
+    def log(...)
       ArMultiThreadedTransactionalTests.synchronize { super }
     end
   end


### PR DESCRIPTION
In ruby 3+, the `log` method was not correctly delegating keyword arguments. Change to `...` delegation syntax

See https://github.com/grosser/ar_multi_threaded_transactional_tests/issues/6

